### PR TITLE
Publish to NPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:7.10
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,30 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: npm test
+
+  deploy:
+    docker:
+      - image: circleci/node:7.10
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: Set up NPM auth
+          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+
+      - run:
+          name: Publish to NPM
+          command: npm publish
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build-job
+      - deploy-job:
+          requires:
+            - build-job
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,12 @@ jobs:
           command: npm publish
 workflows:
   version: 2
-  build-deploy:
+  build-and-deploy:
     jobs:
-      - build-job
-      - deploy-job:
+      - build
+      - deploy:
           requires:
-            - build-job
+            - build
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,5 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+	            only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,4 +50,4 @@ workflows:
             branches:
               only: master
             tags:
-	            only: /^v.*/
+              only: /^v.*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-function-docs",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-function-docs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Generate documentation about TypeScript functions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-function-docs",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Generate documentation about TypeScript functions",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,11 @@
     "type": "git",
     "url": "git+https://github.com/bencoveney/ts-function-docs.git"
   },
-  "author": "Ben Coveney",
+  "author": {
+    "name": "Ben Coveney",
+    "email": "bencoveney@gmail.com",
+    "url": "https://github.com/bencoveney"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/bencoveney/ts-function-docs/issues"
@@ -26,5 +30,8 @@
     "@types/yargs": "^11.0.0",
     "glob": "^7.1.2",
     "ts-node": "^4.1.0"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Theoretically this should sort out publishing to NPM - and you could do so without needing me to assist.

The idea is:
- CircleCI is set up to build (NPM test) on any branches - Tested
- It should also run on PRs
- It should (untested) publish to NPM if:
  - The commit is on master
  - It includes a version tag.

I have not done any work to include the compiled JS as part of this.

I can't work out if the merge commit needs the tag, or if it will look anywhere on the merged branch. If it only looks on the merged branch then we may need to push to master to release new versions.

The CircleCI `NPM_TOKEN` environment variable has been set - we are using config version 2.0.

If you want to check my logic (config files are not my strong point) here are the resources I have been working from:
- https://docs.npmjs.com/cli/version
- https://circleci.com/docs/1.0/npm-continuous-deployment/
- https://circleci.com/docs/2.0/deployment-integrations/
- https://circleci.com/docs/2.0/workflows/#git-tag-job-execution