### PR TITLE
Include compiled javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# Compiled javascript
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ typings/
 
 # dotenv environment variables file
 .env
-
-# Compiled javascript
-dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-function-docs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-function-docs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Generate documentation about TypeScript functions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generate documentation about TypeScript functions",
   "main": "index.js",
   "scripts": {
+    "prepublishOnly": "tsc",
     "test": "ts-node src/index.ts"
   },
   "repository": {

--- a/src/buildModel.ts
+++ b/src/buildModel.ts
@@ -81,11 +81,11 @@ function getDescendantOfKind<
                 result = result.concat(child as NodeType);
             } else {
                 // Search deeper if not a match.
-                result.concat(
+                result = result.concat(
                     getDescendantOfKind(
                         child,
                         kind
-                    )
+                    ) as NodeType[]
                 );
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
         "preserveConstEnums": true,
         "sourceMap": true,
         "target": "es2016",
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "declaration": true,
+        "outDir": "./dist",
     },
     "include": [
         "src/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "target": "es2016",
         "experimentalDecorators": true,
         "declaration": true,
-        "outDir": "./dist",
+        "outDir": "./dist"
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
Satisfies #12 

I don't think we should be putting the built JS on source control, but I don't think we can .gitignore the dist/ directory because we want it to be included when we publish to NPM.